### PR TITLE
fixed ordering issue in POST /coach/session and POST /coach/exercise

### DIFF
--- a/backend/coach_templates.py
+++ b/backend/coach_templates.py
@@ -201,9 +201,14 @@ def createSession(token_claims):
     
     # find current max order value for sessions belonging to the passed in coach_template_id
     max_order = db.session.query(func.max(CoachSession.order)).filter_by(coach_template_id=body['coach_template_id']).scalar()
-    # 
-    # increment the order by 1
-    max_order += 1
+    
+    # if no sessions exist for this template, the newly created session will have order = 1
+    if max_order is None:
+        max_order = 1
+    else:
+        # increment the order by 1
+        max_order += 1
+
     # create the new session with name, coach_template_id, and order
     new_session = CoachSession(name=body['name'], coach_template_id=body['coach_template_id'], order=max_order)
     
@@ -218,7 +223,7 @@ def createSession(token_claims):
         raise
 
     # retrieve created session
-    session = CoachSession.query.filter_by(name=body['name']).first()
+    session = CoachSession.query.filter_by(name=body['name'], coach_template_id=body['coach_template_id']).first()
 
     result = coach_session_schema.dump(session)
     
@@ -237,9 +242,14 @@ def createCoachExercise(token_claims):
     
     # find current max order value for sexercise belonging to the passed in coach_session_id
     max_order = db.session.query(func.max(CoachExercise.order)).filter_by(coach_session_id=body['coach_session_id']).scalar()
-    # 
-    # increment the order by 1
-    max_order += 1
+
+    # if no sessions exist for this template, the newly created session will have order = 1
+    if max_order is None:
+        max_order = 1
+    else:
+        # increment the order by 1
+        max_order += 1
+
     # create the new coach exercise with coach_exercise_id, coach_session_id, and order
     new_exercise = CoachExercise(exercise_id=body['exercise_id'], coach_session_id=body['coach_session_id'], order=max_order)
     
@@ -287,7 +297,6 @@ def createExercise(token_claims):
 
     # retrieve created exercises
     exercises = Exercise.query.all()
-
     result = exercise_schemas.dump(exercises)
     
     return {


### PR DESCRIPTION
- POST  /coach/session
Issue arises when they are no sessions created for a template, in this case we wouldn't need to increment an order variable. Instead, just set the order variable to 1
    * also added an extra check in the retrieval of sessions from the database

- POST /coach/exercise
Issue arises when they are no exercises created for a session, in this case we wouldn't need to increment an order variable. Instead, just set the order variable to 1