### PR TITLE
POST Client Templates

### DIFF
--- a/backend/models/client_templates.py
+++ b/backend/models/client_templates.py
@@ -87,17 +87,23 @@ class ClientTemplate(db.Model):
     end_date = db.Column(db.String, nullable=True)
     # many to one relationship with Users table
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user = db.relationship('User', lazy=True, uselist=False, single_parent=True, primaryjoin="User.id==ClientTemplate.user_id")
     completed = db.Column(db.Boolean, nullable=False)
     # one to many relationship with Client_sessions
     sessions = db.relationship('ClientSession', cascade="all, delete-orphan", lazy=True, order_by="ClientSession.order")
     # one to many relationship with Check_ins table
     check_ins = db.relationship('CheckIn', cascade="all, delete-orphan", lazy=True)
 
+# This partial user schema is used in retrieving templates
+class PartialUserSchema(ma.Schema):
+    class Meta:
+        fields = ('first_name', 'last_name', 'email')
 
 class ClientTemplateSchema(ma.Schema):
     sessions = ma.Nested(PartialClientSessionSchema, many=True)
+    user = ma.Nested(PartialUserSchema, many=False)
     class Meta:
-        fields = ('id', 'name', 'start_date', 'end_date', 'user_id', 'completed', 'sessions')
+        fields = ('id', 'name', 'start_date', 'end_date', 'user_id', 'completed', 'sessions', 'user')
 
 client_template_schema = ClientTemplateSchema()
 client_template_schemas = ClientTemplateSchema(many=True)


### PR DESCRIPTION
This PR finished all POST related endpoints for client templates, in particular:

- POST `/client/template`. Creates a client template based on a current coach template and specified reps, sets and weight of each exercise.
- POST `/client/session`. Has 2 different functionalities as explained in the docs.
1. If user has a role of COACH, it adds a session at the end of their template while creating client_exercises from the supplied exercises, marks session as non-completed.
2. If user has a role of CLIENT, it adds a session at the end of the clients template while creating training_entries from the supplied exercises, marks session as completed.