### PR TITLE
I2 fixes: email format & next session

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -10,10 +10,14 @@ import uuid
 def login():
     body = request.get_json(force=True)
 
+    #  trim the email to remove unnecessary spaces
+    email = body['email'].strip()
+    # convert input email to lowercase
+    email = email.lower()
     # Validate that the email is the correct format
     try:
-        v = validate_email(body['email']) # validate and get info
-        body['email'] = v["email"] # replace with normalized form
+        v = validate_email(email) # validate and get info
+        email = v["email"] # replace with normalized form
     except EmailNotValidError as e:
         # email is not valid, return error code
         return {
@@ -21,7 +25,7 @@ def login():
         }, 406
 
     # Grab user from the database given email and password combination
-    user = User.query.filter_by(email=body['email']).first()
+    user = User.query.filter_by(email=email).first()
     if user == None:
         return {
             "error": "Invalid username or password"

--- a/backend/client_templates.py
+++ b/backend/client_templates.py
@@ -260,10 +260,11 @@ def getNextClientSession(token_claims):
         }, 404
 
     for session in template.sessions:
-        if session.completed == True:
-            next
-        else:
+        if session.completed == False:
             nextSession = session
+            break
+        else:
+            next
 
     result = client_session_schema.dump(nextSession)
 

--- a/backend/client_templates.py
+++ b/backend/client_templates.py
@@ -199,6 +199,33 @@ def getClientSession(token_claims):
 
     return sessionResult
 
+@app.route("/client/session/next", methods=["GET"])
+@http_guard(renew=True, nullable=False)
+def getNextClientSession(token_claims):
+    # Any logged in user should be able to access this method
+    client_id = request.args.get('client_id')
+
+    if client_id == None:
+        return {
+            "error": "No query parameter client_id found in request"
+        }, 400
+    # get the active tempalte
+    template = ClientTemplate.query.filter_by(user_id=client_id, active=True).first()
+    if template == None:
+        return {
+            "error": "No active template found with client_id: " + client_id
+        }, 404
+
+    for session in template.sessions:
+        if session.completed == True:
+            next
+        else:
+            nextSession = session
+
+    result = client_session_schema.dump(nextSession)
+
+    return result
+
 @app.route("/client/session", methods=["POST"])
 @http_guard(renew=True, nullable=False)
 def createClientSession(token_claims):

--- a/backend/client_templates.py
+++ b/backend/client_templates.py
@@ -263,8 +263,6 @@ def getNextClientSession(token_claims):
         if session.completed == False:
             nextSession = session
             break
-        else:
-            next
 
     result = client_session_schema.dump(nextSession)
 

--- a/backend/coach_templates.py
+++ b/backend/coach_templates.py
@@ -217,14 +217,6 @@ def createSession(token_claims):
             "error": "Must specify coach_template_id (integer) and name (string))"
         }, 400
     
-    # check if template name is available, no duplicates allowed
-    check_duplicate = CoachSession.query.filter_by(name=body['name'], coach_template_id=body['coach_template_id']).first()
-
-    if check_duplicate:
-        return {
-            "error": "Session name already exists for this template"
-        }, 400
-    
     # find current max order value for sessions belonging to the passed in coach_template_id
     max_order = db.session.query(func.max(CoachSession.order)).filter_by(coach_template_id=body['coach_template_id']).scalar()
     

--- a/backend/user.py
+++ b/backend/user.py
@@ -71,10 +71,17 @@ def deleteUser(token_claims):
 def signUp():
     body = request.get_json(force=True)
 
+    #  trim the email to remove unnecessary spaces
+    email = body['email'].strip()
+    print(email)
+    # convert input email to lowercase
+    email = email.lower()
+    print(email)
+
     # Validate that the email is the correct format
     try:
-        v = validate_email(body['email']) # validate and get info
-        body['email'] = v["email"] # replace with normalized form
+        v = validate_email(email) # validate and get info
+        email = v["email"] # replace with normalized form
     except EmailNotValidError as e:
         # email is not valid, return error code
         return {
@@ -100,7 +107,7 @@ def signUp():
     # Create the user with the encoded password
     user = User(
         first_name=body['first_name'], last_name=body['last_name'],
-        email=body['email'], password=encodedPassword,
+        email=email, password=encodedPassword,
         approved=False, role=body['role'],
         verified=False
     )

--- a/test_endpoints.py
+++ b/test_endpoints.py
@@ -273,106 +273,6 @@ def test_get_user(client, db_session):
     resp, code = request(client, "GET", url)
     assert code == 200 and resp != None
     assert resp['user']['id'] == client_user['user']['id']
-    
-
-#  ----------------- CLIENT TEMPLATES -----------------
-def test_get_client_template(client, db_session):
-    # Create and sign into the client
-    user = sign_up_user_for_testing(client, test_client)
-    assert user['user'] != None
-    assert user['user']['role'] == 'CLIENT'
-
-    login_resp = login_user_for_testing(client, test_client)
-    assert login_resp['user']['id'] != None and login_resp['user']['id'] != ""
-
-    # Create a template for retrieval
-    template = generate_client_template_model()
-    template.user_id = user['user']['id']
-    db_session.add(template)
-    db_session.commit()
-    db_session.refresh(template)
-
-    # Retrieve template using api
-    url = '/client/template?id={}'.format(str(template.id))
-    resp, code = request(client, "GET", url)
-    assert code == 200
-    assert resp != None
-    assert resp['id'] == template.id
-
-def test_get_client_templates(client, db_session):
-    # Create and sign into the client
-    user = sign_up_user_for_testing(client, test_client)
-    assert user['user'] != None
-    assert user['user']['role'] == 'CLIENT'
-
-    login_resp = login_user_for_testing(client, test_client)
-    assert login_resp['user']['id'] != None and login_resp['user']['id'] != ""
-
-    # Create 2 templates for multiple template retrieval
-    template1 = generate_client_template_model()
-    template2 = generate_client_template_model()
-    template1.user_id = user['user']['id']
-    template2.user_id = user['user']['id']
-    db_session.add(template1)
-    db_session.add(template2)
-    db_session.commit()
-    db_session.refresh(template1)
-    db_session.refresh(template2)
-
-    url = '/client/templates?user_id={}'.format(str(user['user']['id']))
-    resp, code = request(client, "GET", url)
-    assert code == 200
-    assert len(resp['templates']) == 2
-    assert resp['templates'][0]['id'] == template1.id or resp['templates'][0]['id'] == template2.id
-    assert resp['templates'][1]['id'] == template1.id or resp['templates'][1]['id'] == template2.id
-
-def test_post_client_template(client, db_session):
-    # Create a coach to create the template and a client to assign it to
-    coach_user = sign_up_user_for_testing(client, test_coach)
-    assert coach_user['user'] != None
-    assert coach_user['user']['role'] == 'COACH'
-
-    client_user = sign_up_user_for_testing(client, test_client)
-    assert client_user['user'] != None
-    assert client_user['user']['role'] == 'CLIENT'
-
-    # Sign in as the coach
-    login_resp = login_user_for_testing(client, test_coach)
-    assert login_resp['user']['id'] != None and login_resp['user']['id'] != ""
-
-    # Create a coach template to assign to a client
-    coach_template = generate_coach_template_model(db_session, 1)
-    db_session.add(coach_template)
-    db_session.commit()
-    db_session.refresh(coach_template)
-    
-    # Create a client template using this coach template
-    data = {
-        'coach_template_id': coach_template.id,
-        'client_id': client_user['user']['id'],
-        'sessions': []
-    }
-    # Specify the sets, reps and weight of the coach exercises within the sessions
-    for coach_session in coach_template.sessions:
-        session = {'id': coach_session.id, 'coach_exercises': []}
-        for coach_exercise in coach_session.coach_exercises:
-            session['coach_exercises'].append({
-                'id': coach_exercise.id,
-                'sets': 5,
-                'reps': 5,
-                'weight': 315
-            })
-        data['sessions'].append(session)
-
-    resp, code = request(client, "POST", '/client/template', data=data)
-    assert code == 200
-    assert resp != None
-    assert resp['name'] == coach_template.name and resp['user_id'] == client_user['user']['id']
-
-# def test_put_client_template(client, db_session):
-
-
-#  ----------------- HELPER METHODS -------------------
 
 #  ----------------- CLIENT TEMPLATES -----------------
 def test_get_client_template(client, db_session):
@@ -518,6 +418,33 @@ def test_get_client_session(client, db_session):
     assert code == 200
     assert client_session != None
     assert client_session['id'] == client_template['sessions'][0]['id']
+
+def test_get_client_next_session(client, db_session):
+    # Create a coach to create the template and a client to assign it to
+    coach_user = sign_up_user_for_testing(client, test_coach)
+    assert coach_user['user'] != None
+    assert coach_user['user']['role'] == 'COACH'
+
+    client_user = sign_up_user_for_testing(client, test_client)
+    assert client_user['user'] != None
+    assert client_user['user']['role'] == 'CLIENT'
+
+    # Sign in as the coach
+    login_resp = login_user_for_testing(client, test_coach)
+    assert login_resp['user']['id'] != None and login_resp['user']['id'] != ""
+
+    # Create the client template, this function returns the coach_template used to assign to a client
+    client_template, code, coach_template = create_client_template(client, db_session, client_user['user']['id'])
+    assert code == 200
+    assert client_template != None
+    assert client_template['name'] == coach_template.name and client_template['user_id'] == client_user['user']['id']
+
+    # Retrieve a particular session from the client template
+    url = '/client/session/next?client_id={}'.format(client_user['user']['id'])
+    next_session, code = request(client, 'GET', url)
+    assert code == 200
+    assert next_session != None
+    assert next_session['completed'] == False and next_session['client_template_id'] == client_template['id'] and client_template['active'] == True
 
 def test_post_client_session(client, db_session):
     # Create a coach to create the template and a client to assign it to


### PR DESCRIPTION
- `GET /client/session/next`returns the next client session in the active client template
    added a test case for this
- `POST /auth/login` and `POST /signup`
    updated the formatting of emails so that white spaces before and after are trimmed
    and convert email to lower case

- removed the check for duplicate session names in POST /coach/session