### PR TITLE
Create Exercises On Coach Submit

### DIFF
--- a/test_endpoints.py
+++ b/test_endpoints.py
@@ -969,13 +969,29 @@ def test_post_coach_session(client, db_session):
 
     data = {
         'coach_template_id': resp['id'],
-        'name': 'Feet Day'
+        'name': 'Feet Day',
+        'coach_exercises': [
+            {
+                "exercise_id": 1,
+                "order": 1
+            },
+            {
+                "category": "Back",
+                "name": "Deadlifts",
+                "order": 2
+            },
+            {
+                "exercise_id": 2,
+                "order": 3
+            }
+	    ]
     }
 
     # Test creating a client session as a coach (exercises should be added into exercises)
     coach_session_1, code = request(client, "POST", '/coach/session', data=data)
     assert code == 200
     assert coach_session_1['name'] == 'Feet Day'
+    assert len(coach_session_1['coach_exercises']) == 3
 
 
 


### PR DESCRIPTION
This endpoint adds functionality to create new exercises on COACH template and session creation. Changes are:
- `POST /coach/template`. Each coach_exercise needs to specify EITHER an exercise_id or a category and name pair. If the latter, then the exercise will be created in the coach's exercise repository
- `POST /coach/session`. Can now accept an optional list of coach_exercises where each coach_exercise needs to specify EITHER an exercise_id or a category and name pair.

Tests were updated and all pass