### PR TITLE
Slugify

### DIFF
--- a/backend/client_templates.py
+++ b/backend/client_templates.py
@@ -19,7 +19,7 @@ def getClientTemplates(token_claims):
 
     templates = db.session.query(
         ClientTemplate.id, ClientTemplate.name, ClientTemplate.start_date, ClientTemplate.end_date,
-        ClientTemplate.user_id, ClientTemplate.completed
+        ClientTemplate.user_id, ClientTemplate.completed, ClientTemplate.active
     ).filter(ClientTemplate.user_id == user_id)
 
     result = client_template_schemas.dump(templates)

--- a/backend/coach_templates.py
+++ b/backend/coach_templates.py
@@ -47,7 +47,7 @@ def coachTemplate(token_claims):
     
     if id == None:
         return {
-            "error": "No query parameter id found in request"
+            "error": "No query parameter coach_template_id found in request"
         }, 400
     
     template = CoachTemplate.query.filter_by(id=id).first()

--- a/backend/coach_templates.py
+++ b/backend/coach_templates.py
@@ -44,17 +44,26 @@ def coachTemplate(token_claims):
     }, 400
 
     id = request.args.get('coach_template_id')
+    slug = request.args.get('coach_template_slug')
     
-    if id == None:
+    if (id == None and slug == None) or (id != None and slug != None):
         return {
-            "error": "No query parameter coach_template_id found in request"
+            "error": "Pass EITHER coach_template_id OR coach_template_slug in the request parameter"
         }, 400
     
-    template = CoachTemplate.query.filter_by(id=id).first()
+    template = CoachTemplate()
+    if id != None:        
+        template = CoachTemplate.query.filter_by(id=id).first()
+    else:
+        template = CoachTemplate.query.filter_by(slug=slug).first()
 
-    if template == None:
+    if template == None and id != None:
         return {
             "error": "Coach_template not found with given id: " + id
+        }, 404
+    elif template == None and slug != None:
+        return {
+            "error": "Coach_template not found with given slug: " + slug
         }
 
     result = coach_template_schema.dump(template)
@@ -73,17 +82,27 @@ def coachSession(token_claims):
     }, 400
 
     id = request.args.get('coach_session_id')
-    if id == None:
+    slug = request.args.get('coach_session_slug')
+
+    if (id == None and slug == None) or (id != None and slug != None):
         return {
-            "error": "No query parameter id found in request"
+            "error": "Pass EITHER coach_session_id OR coach_session_slug in the request parameter"
         }, 400
     
-    session = CoachSession.query.filter_by(id=id).first()
+    session = CoachSession()
+    if id != None:
+        session = CoachSession.query.filter_by(id=id).first()
+    else:
+        session = CoachSession.query.filter_by(slug=slug).first()
 
-    if session == None:
+    if session == None and id != None:
         return {
             "error": "Coach_session not found with given id: " + id
-        }
+        }, 404
+    elif session == None and slug != None:
+        return {
+            "error": "Coach_session not found with given slug: " + slug
+        }, 404
 
     result = coach_session_schema.dump(session)
     

--- a/backend/coach_templates.py
+++ b/backend/coach_templates.py
@@ -261,7 +261,20 @@ def createSession(token_claims):
         return {
             "error": "Must specify coach_template_id (integer) and name (string))"
         }, 400
+
+    coach_template = CoachTemplate.query.get(body['coach_template_id'])
+    if coach_template == None:
+        return {
+            "error": "No coach template found with the supplied coach_template_id"
+        }, 404
     
+    # Check for duplicate session name
+    coach_session = CoachSession.query.filter_by(coach_template_id=coach_template.id, name=body['name']).first()
+    if coach_session != None:
+        return {
+            "error": "Duplicate session name found"
+        }, 409
+
     # find current max order value for sessions belonging to the passed in coach_template_id
     max_order = db.session.query(func.max(CoachSession.order)).filter_by(coach_template_id=body['coach_template_id']).scalar()
     

--- a/backend/helpers/general.py
+++ b/backend/helpers/general.py
@@ -1,0 +1,18 @@
+from backend import db
+
+def makeTemplateSlugUnique(template_model, slug):
+    """
+    Takes in a slugified template name and makes it unique. It does so by querying the db and checking if there are
+    any records LIKE the slug. If there is, then it increments the count and appends it to the slug
+    """
+    existing_slugs = db.session.query(template_model).filter(template_model.slug.contains(slug)).order_by(template_model.slug).all()
+    # Split the slug so we can check if the last word is a number (count), if it is, we increment by 1 and add
+    # it to the end of the slug
+    if len(existing_slugs) != 0:
+        slug_array = str(existing_slugs[len(existing_slugs) - 1].slug).split("-")
+        if slug_array[len(slug_array)-1].isdigit():
+            slug = slug + "-" + str(int(slug_array[len(slug_array)-1]) + 1)
+        else:
+            slug = slug + "-" + "1"
+
+    return slug

--- a/backend/models/client_templates.py
+++ b/backend/models/client_templates.py
@@ -54,6 +54,7 @@ class ClientSession(db.Model):
     client_weight = db.Column(db.Integer, nullable=True)
     comment = db.Column(db.String, nullable=True)
     name = db.Column(db.String, nullable=False)
+    slug = db.Column(db.String, nullable=False)
     order = db.Column(db.Integer, nullable=False)
     completed = db.Column(db.Boolean, nullable=False)
     # many to one relationship with CLient_templates table
@@ -67,7 +68,7 @@ class ClientSessionSchema(ma.Schema):
     exercises = ma.Nested(ClientExerciseSchema, many=True)
     training_entries = ma.Nested(TrainingEntrySchema, many=True)
     class Meta:
-        fields = ('id','client_weight', 'comment', 'name', 'order', 'completed', 'client_template_id', 'exercises', 'training_entries')
+        fields = ('id','client_weight', 'comment', 'name', 'slug', 'order', 'completed', 'client_template_id', 'exercises', 'training_entries')
 
 client_session_schema = ClientSessionSchema()
 client_session_schemas = ClientSessionSchema(many=True)
@@ -75,7 +76,7 @@ client_session_schemas = ClientSessionSchema(many=True)
 # This schema is used to for the templates to pull partial information about sessions
 class PartialClientSessionSchema(ma.Schema):
     class Meta:
-        fields = ('id', 'name', 'order', 'completed')
+        fields = ('id', 'name', 'slug', 'order', 'completed')
 
 # Client_templates Table
 class ClientTemplate(db.Model):
@@ -83,6 +84,7 @@ class ClientTemplate(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String, nullable=False)
+    slug = db.Column(db.String, nullable=False)
     start_date = db.Column(db.String, nullable=False)
     end_date = db.Column(db.String, nullable=True)
     # many to one relationship with Users table
@@ -104,7 +106,7 @@ class ClientTemplateSchema(ma.Schema):
     sessions = ma.Nested(PartialClientSessionSchema, many=True)
     user = ma.Nested(PartialUserSchema, many=False)
     class Meta:
-        fields = ('id', 'name', 'start_date', 'end_date', 'user_id', 'completed', 'sessions', 'user', 'active')
+        fields = ('id', 'name', 'slug', 'start_date', 'end_date', 'user_id', 'completed', 'sessions', 'user', 'active')
 
 client_template_schema = ClientTemplateSchema()
 client_template_schemas = ClientTemplateSchema(many=True)

--- a/backend/models/coach_templates.py
+++ b/backend/models/coach_templates.py
@@ -64,7 +64,7 @@ coach_session_schemas = CoachSessionSchema(many=True)
 # this schema is used for retrieving partial information about a session
 class PartialCoachSessionSchema(ma.Schema):
     class Meta:
-        fields = ('id', 'name', 'order')
+        fields = ('id', 'name', 'slug', 'order')
 
 
 

--- a/backend/models/coach_templates.py
+++ b/backend/models/coach_templates.py
@@ -46,6 +46,7 @@ class CoachSession(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String, nullable=False)
+    slug = db.Column(db.String, nullable=False)
     order = db.Column(db.Integer, nullable=False)
     # many to 1 relationship with Coach_templates table
     coach_template_id = db.Column(db.Integer, db.ForeignKey('Coach_templates.id'), nullable=False)
@@ -55,7 +56,7 @@ class CoachSession(db.Model):
 class CoachSessionSchema(ma.Schema):
     coach_exercises = ma.Nested(CoachExerciseSchema, many=True)
     class Meta:
-        fields = ('id', 'name', 'order', 'coach_template_id', 'coach_exercises')
+        fields = ('id', 'name', 'slug', 'order', 'coach_template_id', 'coach_exercises')
 
 coach_session_schema = CoachSessionSchema()
 coach_session_schemas = CoachSessionSchema(many=True)
@@ -73,13 +74,14 @@ class CoachTemplate(db.Model):
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String)
+    slug = db.Column(db.String, nullable=False)
     # 1 to many relationship with Coach_sessions table
     sessions = db.relationship('CoachSession', cascade="all, delete-orphan", lazy=True, order_by="CoachSession.order")
 
 class CoachTemplateSchema(ma.Schema):
     sessions = ma.Nested(PartialCoachSessionSchema, many=True)
     class Meta:
-        fields = ('id', 'name', 'sessions')
+        fields = ('id', 'name', 'sessions', 'slug')
 
 coach_template_schema = CoachTemplateSchema()
 coach_template_schemas = CoachTemplateSchema(many=True)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'pytest',
         'pytest-flask',
         'pytest-flask-sqlalchemy',
-        'pytest-cov'
+        'pytest-cov',
+        'python-slugify'
     ],
 )

--- a/test_endpoints.py
+++ b/test_endpoints.py
@@ -664,9 +664,9 @@ def generate_coach_template_model(db_session, id):
     db_session.add(Exercise(id=id + 1, category='Latisimus Dorsi', name='Pullups'))
     db_session.commit()
     return CoachTemplate(
-        id=id, name='Test Coach Template', sessions=[
+        id=id, name='Test Coach Template', slug='test-coach-template', sessions=[
             CoachSession(
-                name='Test Session 1', order=1, coach_exercises=[
+                name='Test Session 1', slug='test-session-1', order=1, coach_exercises=[
                     CoachExercise(
                         exercise_id=id, order=1
                     ),
@@ -676,7 +676,7 @@ def generate_coach_template_model(db_session, id):
                 ]
             ),
             CoachSession(
-                name='Test Session 2', order=2, coach_exercises=[
+                name='Test Session 2', slug='test-session-2', order=2, coach_exercises=[
                     CoachExercise(
                         exercise_id=id, order=1
                     ),

--- a/test_endpoints.py
+++ b/test_endpoints.py
@@ -739,7 +739,7 @@ def create_coach_template(client, db_session):
     
     resp, code = request(client, "POST", '/coach/template', data=data)
     return resp, code, coach_template
-    
+
 
 
 #  ----------------- COACH TEMPLATES -----------------
@@ -806,7 +806,7 @@ def test_post_coach_template(client, db_session):
     assert code == 200
     assert resp != None
     assert resp['name'] == coach_template.name
-
+    assert resp['slug'] == 'test-coach-template'
 
 def test_put_coach_template(client, db_session):
     # Create a coach to create the template and a client to assign it to
@@ -918,8 +918,8 @@ def test_post_coach_session(client, db_session):
     coach_session_1, code = request(client, "POST", '/coach/session', data=data)
     assert code == 200
     assert coach_session_1['name'] == 'Feet Day'
+    assert coach_session_1['slug'] == 'feet-day'
     assert len(coach_session_1['coach_exercises']) == 3
-
 
 
 def test_put_coach_session(client, db_session):

--- a/test_endpoints.py
+++ b/test_endpoints.py
@@ -292,7 +292,7 @@ def test_get_client_template(client, db_session):
     db_session.refresh(template)
 
     # Retrieve template using api
-    url = '/client/template?id={}'.format(str(template.id))
+    url = '/client/template?client_template_id={}'.format(str(template.id))
     resp, code = request(client, "GET", url)
     assert code == 200
     assert resp != None
@@ -425,7 +425,7 @@ def test_get_client_session(client, db_session):
     assert client_template['name'] == coach_template.name and client_template['user_id'] == client_user['user']['id']
 
     # Retrieve a particular session from the client template
-    url = '/client/session?template_id={}&session_id={}'.format(client_template['id'], client_template['sessions'][0]['id'])
+    url = '/client/session?client_session_id={}'.format(client_template['id'], client_template['sessions'][0]['id'])
     client_session, code = request(client, 'GET', url)
     assert code == 200
     assert client_session != None


### PR DESCRIPTION
This PR adds slugs to COACH templates and sessions and CLIENT templates and sessions. Notable changes are:
- All responses that include template and session data now include a `slug` field.
- GET `/template` and `/session` now accept EITHER an id or slug (both will work) for both clients and coaches
- GET `/session` by slug needs to accept both a template slug and a session slug
- All changes were updated in the documentation